### PR TITLE
issue-#13 middle 영역 우측 이미지를 output_files 폴더의 이미지로 교체

### DIFF
--- a/oot/data/data_manager.py
+++ b/oot/data/data_manager.py
@@ -97,5 +97,13 @@ class DataManager:
             if not os.path.isfile(out_file):
                 shutil.copy(src_file, out_file)
                 
-                
+    @classmethod
+    def get_output_file(cls):
+        print ('[DataManager] get_output_file() called...')
+
+        out_file_dir = cls.folder_data.folder
+        out_file_name = os.path.basename(cls.folder_data.work_file.name)
+        out_file = os.path.join(out_file_dir, '__OUTPUT_FILES__', out_file_name)
+        
+        return out_file
     

--- a/oot/gui/middle_frame.py
+++ b/oot/gui/middle_frame.py
@@ -69,10 +69,8 @@ class MiddleFrame:
         right_canvas = tk.Canvas(mid_frm, bg='lightgray')
         right_canvas.grid(row=0, column=1, sticky=tk.E+tk.W+tk.N+tk.S)
 
-        img_folder = DataManager.folder_data.folder
         src_file = DataManager.folder_data.work_file.name
-        # TODO: 데이터매니저에서 outfile을 리턴해주는 함수 필요함
-        out_file = src_file
+        out_file = DataManager.get_output_file()
 
         # Reference :
         # - https://www.youtube.com/watch?v=xiGQD2J47nA
@@ -104,9 +102,8 @@ class MiddleFrame:
     @classmethod
     def resetCanvasImages(cls, work_file):
         print ('[MiddleFrame] resetCanvasImages() called...')
-        # TODO: out_file 수정해야함
         src_file = work_file
-        out_file = src_file
+        out_file = DataManager.get_output_file()
 
         cls.src_canvas_worker.changeImageFile(src_file)
         cls.out_canvas_worker.changeImageFile(out_file)


### PR DESCRIPTION
afa9366 feat: middle 영역 우측 이미지를 output_files 폴더의 이미지로 교체
- data_manager.py에 get_output_file() method가 추가되었습니다.
- middle_frame.py의 out_file을 수정했습니다.

![image](https://github.com/Career-Bootcamps/OpenCV-OCR-Translate/assets/147116001/b4e26bb2-7386-4f03-9210-a8fb664b9b8d)