### PR TITLE
issue-#30 top_frame에 저장하기 버튼 추가 및 기능 구현 완료

### DIFF
--- a/oot/control/top_control.py
+++ b/oot/control/top_control.py
@@ -64,3 +64,12 @@ def clicked_next_image():
         return
     print('[TopFrameControl] clickedNextImage() : next image = ', next_img.name)
     ControlManager.changed_work_image(next_img)   
+
+def clicked_save_output():
+    print('[TopFrameControl] clicked_save_output() called!!...')
+    result = DataManager.save_output_file(DataManager.folder_data.work_file.name, MiddleFrame.out_canvas_worker.get_image())
+    if result == True:
+        MiddleFrame.reset_canvas_images(DataManager.folder_data.get_work_file())
+        mb.showinfo("성공", "저장에 성공했습니다")
+    else:
+        mb.showerror("에러", "저장에 실패했습니다")

--- a/oot/gui/top_frame.py
+++ b/oot/gui/top_frame.py
@@ -18,7 +18,7 @@ class TopFrame:
         top_frm = tk.Frame(root)
         top_frm.pack(padx=2, pady=2, fill='both', side='top')
 
-        # top buttons : '이전 이미지', '다음 이미지', '폴더 변경'
+        # top buttons : '이전 이미지', '다음 이미지', '폴더 변경', '결과 저장'
         from oot.control.top_control import clicked_prev_image, clicked_next_image
         btn_prev_image = ttk.Button(top_frm, text='이전 이미지', command=clicked_prev_image)
         btn_next_image = ttk.Button(top_frm, text='다음 이미지', command=clicked_next_image)
@@ -26,6 +26,8 @@ class TopFrame:
         from oot.control.top_control import clicked_change_folder
         btn_change_folder = ttk.Button(top_frm, text='폴더 변경', command=clicked_change_folder)
         
+        from oot.control.top_control import clicked_save_output
+        btn_save_image = ttk.Button(top_frm, text='결과 저장', command=clicked_save_output)
 
         label_curr_file_title = ttk.Label(top_frm, text='작업 파일:')
         TopFrame.label_curr_file_name = ttk.Label(top_frm, text=DataManager.folder_data.work_file.name)
@@ -33,6 +35,7 @@ class TopFrame:
         btn_prev_image.pack(side='left')
         btn_next_image.pack(side='left')
         btn_change_folder.pack(side='left')
+        btn_save_image.pack(side='right')
         label_curr_file_title.pack(side='left')
         TopFrame.label_curr_file_name.pack(side='left')
         

--- a/test/yunjeong/method_test.py
+++ b/test/yunjeong/method_test.py
@@ -1,0 +1,23 @@
+    # data_manager.py save_output_file() 테스트에 사용된 코드
+    @classmethod
+    def save_output_file(cls, src_file, out_image):
+        print ('[DataManager] save_output_file() called...')
+
+        # out_image는 PIL의 Image 객체
+        if out_image is None:
+            print ('[DataManager] save_output_file() : image is None, it can not be saved!')
+       
+        # out_file은 path
+        out_file = cls.get_output_file()
+        print ('[DataManager] save_output_file() : src_file=', src_file)
+        print ('[DataManager] save_output_file() : out_file=', out_file)
+
+        # resized for test
+        resized_image = out_image.resize((500, 500))        
+
+        if out_file is not None:
+            # 확장자에 따라서 저장을 달리함
+            cls.__save_according_ext(out_file, resized_image)
+            print('[DataManager] save_output_file(): Image saved successfully!')
+            return True
+        return False


### PR DESCRIPTION
af7490b feat: #30 top_frame에 저장하기 버튼 추가 및 기능구현

- top_frame.py에 결과 저장 버튼을 생성했습니다.
- 버튼 클릭 시 top_control.py의 clicked_save_output()가 실행됩니다. DataManager의 save_output_file()를 사용하여 저장합니다. 저장에 성공하면 저장된 이미지를 우측에 띄워줍니다.
- DataManager에서 save_output_file()에서 save()는 PIL의 method입니다. 이미지 포맷이 '.jpg.인 경우 PIL에서 지원하지 않는 형식이라 에러가 발생했습니다. 따라서 __init_output_folder를 수정하여 이미지 포맷이 '.jpg'인 경우 확장자를 '.jpeg'로 저장합니다. get_output_file()을 수정하여 원본의 이미지 포맷이 '.jpg'인 경우 '.jpeg'의 경로를 return 합니다.
- __save_according_ext()는 save() 사용 시 'RGBA'로 저장되기 때문에 이미지 포맷이 '.png'가 아닌 경우 에러가 발생하여 'RGB'로 convert하여 save()하는 method입니다.

![image](https://github.com/Career-Bootcamps/OpenCV-OCR-Translate/assets/147116001/fe403d99-319c-4365-9ba3-44cc9b5276f9)
결과 저장 버튼 클릭 시 이미지가 새로 저장됩니다.