### PR TITLE
issue-#30 feat: top_frame에 저장하기 버튼 추가 및 기능 구현

### DIFF
--- a/oot/control/top_control.py
+++ b/oot/control/top_control.py
@@ -64,3 +64,12 @@ def clicked_next_image():
         return
     print('[TopFrameControl] clickedNextImage() : next image = ', next_img.name)
     ControlManager.changed_work_image(next_img)   
+
+def clicked_save_output():
+    print('[TopFrameControl] clicked_save_output() called!!...')
+    result = DataManager.save_output_file(DataManager.folder_data.work_file.name, MiddleFrame.out_canvas_worker.get_image())
+    if result == True:
+        MiddleFrame.reset_canvas_images(DataManager.folder_data.get_work_file())
+        mb.showinfo("성공", "저장에 성공했습니다")
+    else:
+        mb.showerror("에러", "저장에 실패했습니다")

--- a/oot/data/data_manager.py
+++ b/oot/data/data_manager.py
@@ -1,7 +1,9 @@
 import glob
 import os
-from typing import cast
 import shutil
+from typing import cast
+from typing import cast
+from PIL import ImageTk, Image
 
 # FolderData > FileData > TextData
 
@@ -113,6 +115,28 @@ class DataManager:
         
         return out_file
     
+    @classmethod
+    def save_output_file(cls, src_file, out_image):
+        print ('[DataManager] save_output_file() called...')
+
+        # out_image는 PIL의 Image 객체
+        if out_image is None:
+            print ('[DataManager] save_output_file() : image is None, it can not be saved!')
+
+        # out_file은 path
+        out_file = cls.get_output_file()
+        print ('[DataManager] save_output_file() : src_file=', src_file)
+        print ('[DataManager] save_output_file() : out_file=', out_file)
+
+        if out_file is not None:
+            if out_file.lower().endswith(("png")) == False:
+                out_image.convert("RGB").save(out_file)
+            else:
+                out_image.save(out_file)
+            print('[DataManager] save_output_file(): Image saved successfully!')
+            return True
+        return False
+
     @classmethod
     def get_prev_imagefile(cls, img_file):
         print('[DataManager] getPrevImageFile() called!!...')

--- a/oot/gui/top_frame.py
+++ b/oot/gui/top_frame.py
@@ -18,14 +18,16 @@ class TopFrame:
         top_frm = tk.Frame(root)
         top_frm.pack(padx=2, pady=2, fill='both', side='top')
 
-        # top buttons : '이전 이미지', '다음 이미지', '폴더 변경'
+        # top buttons : '이전 이미지', '다음 이미지', '폴더 변경', '결과 저장'
         from oot.control.top_control import clicked_prev_image, clicked_next_image
         btn_prev_image = ttk.Button(top_frm, text='이전 이미지', command=clicked_prev_image)
         btn_next_image = ttk.Button(top_frm, text='다음 이미지', command=clicked_next_image)
         
         from oot.control.top_control import clicked_change_folder
         btn_change_folder = ttk.Button(top_frm, text='폴더 변경', command=clicked_change_folder)
-        
+
+        from oot.control.top_control import clicked_save_output
+        btn_save_image = ttk.Button(top_frm, text='결과 저장', command=clicked_save_output)        
 
         label_curr_file_title = ttk.Label(top_frm, text='작업 파일:')
         TopFrame.label_curr_file_name = ttk.Label(top_frm, text=DataManager.folder_data.work_file.name)
@@ -33,6 +35,7 @@ class TopFrame:
         btn_prev_image.pack(side='left')
         btn_next_image.pack(side='left')
         btn_change_folder.pack(side='left')
+        btn_save_image.pack(side='right')
         label_curr_file_title.pack(side='left')
         TopFrame.label_curr_file_name.pack(side='left')
         


### PR DESCRIPTION
dc78813 feat: #30 top_frame에 저장하기 버튼 추가 및 기능 구현

- top_frame.py : 결과 저장 버튼을 생성했습니다.
- clicked_save_output() : 결과 저장 버튼 클릭 시 실행됩니다. DataManager의 save_output_file()를 사용하여 저장합니다. 저장에 성공하면 저장된 이미지를 우측에 띄워줍니다.
- save_output_file() : method 내에서 사용되는 out_image는 PIL의 open()을 통한 'RGBA' 포맷의 이미지입니다. 'RGB' 포맷을 가진 jpg, gif의 경우 저장 시 오류가 발생합니다. 따라서 open()된 이미지를 'RGB'로 convert하여 저장합니다.