### PR TITLE
issue-#45 feat: remove_tab 텍스트 찾기 버튼 클릭 시 ocr 수행 및 DataManager 업데이트

### DIFF
--- a/oot/control/low_remove_control.py
+++ b/oot/control/low_remove_control.py
@@ -1,0 +1,7 @@
+from oot.data.data_manager import DataManager
+
+
+def clicked_search_text(): 
+    print('[low_remove_control] clicked_search_text() called!!...')
+    texts = DataManager.get_texts_from_image()
+    print(f'[low_remove_control] clicked_search_text() result : {texts}')

--- a/oot/gui/subframes/remove_frame.py
+++ b/oot/gui/subframes/remove_frame.py
@@ -1,7 +1,6 @@
 from tkinter import ttk
 
 
-
 #------------------------------------------------------------------------------
 # Low frame - remove tab : low frame remove tab controls
 #------------------------------------------------------------------------------
@@ -14,7 +13,8 @@ class RemoveFrame:
         self.frame_btn = ttk.Frame(root)
         self.frame_btn.pack(padx=2, pady=2, fill='x')
         
-        btn_search_text = ttk.Button(self.frame_btn, text='텍스트 찾기')
+        from oot.control.low_remove_control import clicked_search_text
+        btn_search_text = ttk.Button(self.frame_btn, text='텍스트 찾기', command=clicked_search_text)
         btn_remove_text = ttk.Button(self.frame_btn, text='텍스트 지우기')
         btn_revoke_image = ttk.Button(self.frame_btn, text='원상태 복원')
 


### PR DESCRIPTION
f5285a3 feat: #45 remove_tab 텍스트 찾기 버튼 클릭 시 ocr 수행 및 DataManager 업데이트

- remove_frame의 텍스트 찾기 버튼 클릭 시 clicked_search_text 메서드가 실행됩니다.
- clicked_search_text에서는 DataManager.get_texts_from_image()를 통해 ocr 수행한 결과를 받아옵니다.
- get_texts_from_image()에서는 기존에 읽은 데이터의 경우 TextData의 texts를 반환하고, 그렇지 않은 경우 새로 ocr을 수행합니다. text를 찾을 수 없는 경우에는 경고창을 통해 안내합니다.
- get_texts_from_image()의 결과로 FileData의 texts, ocr_executed, TextData의 text, position이 update됩니다.