### PR TITLE
feat: #46 remove_tab에 ocr 수행 결과 출력 및 폴더, 이미지 변경시 초기화

### DIFF
--- a/oot/control/low_remove_control.py
+++ b/oot/control/low_remove_control.py
@@ -1,7 +1,46 @@
+from oot.gui.subframes.remove_frame import RemoveFrame
 from oot.data.data_manager import DataManager
-
 
 def clicked_search_text(): 
     print('[low_remove_control] clicked_search_text() called!!...')
     texts = DataManager.get_texts_from_image()
     print(f'[low_remove_control] clicked_search_text() result : {texts}')
+    
+    if texts != None:
+        scrollable_frame = RemoveFrame.get_frame()
+        scrollable_frame.reset(texts)
+
+def selected_radio_list_in_remove_tab(text):
+    print ('[RemoveFrameControl] selected_radio_list_in_remove_tab() called!!...')
+    text_info = text.split('|', 1)
+
+    # get selected item's info (id, text, status)
+    selected_item_id = int(text_info[0])
+    selected_item_text = text_info[1]
+    print ('[RemoveFrameControl] selected_radio_list_in_remove_tab() : id = ', selected_item_id)
+    print ('[RemoveFrameControl] selected_radio_list_in_remove_tab() : text = ', selected_item_text)
+
+    # write text to original text area of write tab in low frame
+    from oot.gui.low_frame import LowFrame
+    LowFrame.reset_translation_target_text_in_write_tab(selected_item_text)
+
+    from oot.gui.middle_frame import MiddleFrame
+    from oot.data.data_manager import DataManager
+    MiddleFrame.reset_canvas_images(DataManager.folder_data.get_work_file())
+
+def selected_check_list_in_remove_tab(text):
+    from oot.gui.subframes.remove_frame import RemoveFrame
+    print ('[RemoveFrameControl] selected_check_list_in_remove_tab() called!!...')
+    text_info = text.split('|', 1)
+
+    # get selected item's info (id, text, status)
+    selected_item_id = int(text_info[0])
+    selected_item_text = text_info[1]
+    selected_item_status = RemoveFrame.get_status_of_check_list(selected_item_id)
+    print ('[RemoveFrameControl] selected_check_list_in_remove_tab() : id = ', selected_item_id)
+    print ('[RemoveFrameControl] selected_check_list_in_remove_tab() : text = ', selected_item_text)
+    print ('[RemoveFrameControl] selected_check_list_in_remove_tab() : status = ', selected_item_status.get())
+    from oot.gui.middle_frame import MiddleFrame
+    from oot.data.data_manager import DataManager
+    MiddleFrame.reset_canvas_images(DataManager.folder_data.get_work_file())
+

--- a/oot/control/top_control.py
+++ b/oot/control/top_control.py
@@ -9,6 +9,7 @@ sys.path.append('.')
 from oot.data.data_manager import DataManager
 from oot.gui.top_frame import TopFrame
 from oot.gui.middle_frame import MiddleFrame
+from oot.gui.subframes.remove_frame import RemoveFrame
 from oot.gui.subframes.write_frame import WriteFrame
 
 def __check_work_folder(work_dir):
@@ -31,6 +32,7 @@ def clicked_change_folder():
             DataManager.reset_work_folder(dir_path)
             
             # 이전 문자 인식결과 초기화
+            RemoveFrame.reset_remove_tab_data()
             WriteFrame.reset_write_tab_data()
             
             # UI 업데이트

--- a/oot/data/data_manager.py
+++ b/oot/data/data_manager.py
@@ -246,6 +246,10 @@ class DataManager:
         print('[ControlManager.changedWorkImage] work_img=', work_file.get_file_name())
         DataManager.set_work_file(work_file) # 현재 작업 파일을 업데이트
 
+        # clear all data in 'remove tab' of 'RemoveFrame'
+        from oot.gui.subframes.remove_frame import RemoveFrame
+        RemoveFrame.reset_remove_tab_data()
+
         # clear all data in 'write tab' of 'WriteFrame'
         from oot.gui.subframes.write_frame import WriteFrame
         WriteFrame.reset_write_tab_data()
@@ -290,7 +294,7 @@ class DataManager:
         ocr_executed_texts_list = []
 
         if work_file.is_ocr_executed():
-            mb.showinfo("알림", "이미 읽은 데이터입니다.")
+            print('[DataManager] get_texts_from_image() called!!... 이미 읽은 데이터입니다.')
             ocr_executed_texts_list = work_file.get_texts_as_string()
             return ocr_executed_texts_list
         

--- a/oot/gui/low_frame.py
+++ b/oot/gui/low_frame.py
@@ -48,7 +48,7 @@ class LowFrame:
         low_frm.add(mosaic_tab, text='모자이크')
         
         # init remove tab
-        remove_tab_content = RemoveFrame(remove_tab)
+        self.remove_frame = RemoveFrame(remove_tab)
         
         # init write tab
         self.write_frame = WriteFrame(write_tab, root)
@@ -61,10 +61,6 @@ class LowFrame:
 
     @classmethod
     def get_status_of_check_list_in_remove_tab(cls, idx):
-        pass
-
-    @classmethod
-    def reset_remove_tab_data(cls, texts=None):
         pass
 
     @classmethod

--- a/oot/gui/subframes/common.py
+++ b/oot/gui/subframes/common.py
@@ -49,10 +49,10 @@ class ScrollableList(tk.Frame):
                 if self.list_type == ScrollableListType.CHECK_BUTTON:
                     # Reference : checkbutton example getting value in callback
                     # - https://arstechnica.com/civis/viewtopic.php?t=69728
-                    from oot.control.low_write_control import selectedCheckListInRemoveTab
-                    cb = tk.Checkbutton(self, text=t, command=lambda i=self.__get_indexed_text(idx,t): selectedCheckListInRemoveTab(i), var=self.list_values[idx])
+                    from oot.control.low_remove_control import selected_check_list_in_remove_tab
+                    cb = tk.Checkbutton(self, text=t, command=lambda i=self.__get_indexed_text(idx,t): selected_check_list_in_remove_tab(i), var=self.list_values[idx])
                 elif self.list_type == ScrollableListType.RADIO_BUTTON:
-                    from oot.control.low_write_control import selectedRadioListInRemoveTab
+                    from oot.control.low_remove_control import selectedRadioListInRemoveTab
                     cb = tk.Radiobutton(self, text=t, command=lambda i=self.__get_indexed_text(idx,t): selectedRadioListInRemoveTab(i), variable=self.radio_value, value=idx)
                 else:
                     cb = tk.Checkbutton(self, text=t)

--- a/oot/gui/subframes/remove_frame.py
+++ b/oot/gui/subframes/remove_frame.py
@@ -1,5 +1,7 @@
 from tkinter import ttk
 
+from oot.gui.subframes.common import ScrollableList, ScrollableListType
+
 
 #------------------------------------------------------------------------------
 # Low frame - remove tab : low frame remove tab controls
@@ -23,15 +25,25 @@ class RemoveFrame:
         btn_revoke_image.pack(side='left')
 
         remove_tab_down_frm = ttk.Frame(root)
+        RemoveFrame.__set_remove_tab_text_list(remove_tab_down_frm)
+
+    @classmethod
+    def __set_remove_tab_text_list(cls, remove_tab_down_frm):
         remove_tab_down_frm.pack(padx=2, pady=2, fill='both', expand=True)
-
-        from oot.gui.subframes.common import ScrollableList, ScrollableListType
-        remove_tab_text_list = ScrollableList(remove_tab_down_frm, ScrollableListType.CHECK_BUTTON)
-
-        remove_tab_text_list.pack(side="top", fill="x", expand=True)
-        remove_tab_text_list.reset()
-        self.remove_tab_text_list = remove_tab_text_list
-
+        cls.remove_tab_text_list = ScrollableList(remove_tab_down_frm, ScrollableListType.CHECK_BUTTON)
+        cls.remove_tab_text_list.pack(side="top", fill="x", expand=True)
+    
     @classmethod
     def get_frame(cls):
         return cls.remove_tab_text_list
+
+    @classmethod
+    def get_status_of_check_list(cls, idx):
+        print ('[RemoveFrame] get_status_of_check_list() called...')
+        return cls.remove_tab_text_list.list_values[idx]
+    
+    @classmethod
+    def reset_remove_tab_data(cls, texts=None):
+        print ('[LowFrame] resetRemoveTabData() called...')
+        print ('[LowFrame] resetRemoveTabData() : texts=', texts)
+        cls.remove_tab_text_list.reset(texts)


### PR DESCRIPTION
10da989 feat: #46 remove_tab에 ocr 수행 결과 출력 및 폴더, 이미지 변경시 초기화

- 텍스트 찾기 버튼 클릭 시 clicked_search_text()가 실행되며 TextData의 text가 반환됩니다. text가 있는 경우 텍스트가 체크박스 형태로 표시됩니다.
- 표시된 텍스트는 중복으로 체크가 가능하며 텍스트가 많은 경우 scroll 기능이 동작합니다.
- 폴더 변경, 이미지 변경 시 remove_tab의 텍스트 표시란이 초기화됩니다.

![image](https://github.com/user-attachments/assets/6194deef-b8b3-4d81-bb1e-63b3923ae6f8)
