### PR TITLE
feat: #49 remove_tab 원상태 복원 기능 구현

### DIFF
--- a/oot/control/low_remove_control.py
+++ b/oot/control/low_remove_control.py
@@ -38,3 +38,9 @@ def clicked_remove_text():
     from oot.gui.middle_frame import MiddleFrame
     print('[low_remove_control] clicked_search_text() called!!...')
     MiddleFrame.remove_selected_texts()
+
+def clicked_revoke_image(): 
+    from oot.gui.middle_frame import MiddleFrame
+    print('[low_remove_control] clicked_revoke_image() called!!...')
+    temp_file = DataManager.get_work_file().get_file_name()
+    MiddleFrame.temp_out_canvas_images(temp_file)

--- a/oot/gui/middle_frame.py
+++ b/oot/gui/middle_frame.py
@@ -5,6 +5,7 @@ from PIL import ImageTk, Image
 import sys
 sys.path.append('.')
 from oot.gui.low_frame import LowFrame
+from oot.data.data_manager import DataManager
 
 class CanvasWorker:
     def __init__(self, img_file, canvas):
@@ -131,6 +132,12 @@ class MiddleFrame:
         MiddleFrame.src_canvas_worker = CanvasWorker(src_file, left_canvas)
         MiddleFrame.out_canvas_worker = CanvasWorker(out_file, right_canvas)
 
+    @classmethod
+    def temp_out_canvas_images(cls, temp_file):
+        # temp_file을 임시적으로 out_file로 지정하여 출력하는 메소드(저장은 별개)
+        print ('[MiddleFrame] temp_out_canvas_images() called...')
+        cls.out_canvas_worker.change_image_file(temp_file)
+        cls.redraw_canvas_images()
 
     @classmethod
     def redraw_canvas_images(cls):

--- a/oot/gui/subframes/remove_frame.py
+++ b/oot/gui/subframes/remove_frame.py
@@ -16,10 +16,10 @@ class RemoveFrame:
         self.frame_btn = ttk.Frame(root)
         self.frame_btn.pack(padx=2, pady=2, fill='x')
         
-        from oot.control.low_remove_control import clicked_search_text, clicked_remove_text
+        from oot.control.low_remove_control import clicked_search_text, clicked_remove_text, clicked_revoke_image
         btn_search_text = ttk.Button(self.frame_btn, text='텍스트 찾기', command=clicked_search_text)
         btn_remove_text = ttk.Button(self.frame_btn, text='텍스트 지우기', command=clicked_remove_text)
-        btn_revoke_image = ttk.Button(self.frame_btn, text='원상태 복원')
+        btn_revoke_image = ttk.Button(self.frame_btn, text='원상태 복원', command=clicked_revoke_image)
 
         btn_search_text.pack(side='left')
         btn_remove_text.pack(side='left')


### PR DESCRIPTION
b782561 feat: #49 remove_tab 원상태 복원 기능 구현

- remove_tab의 원상태 복원 버튼 클릭 시 clicked_revoke_image()가 실행됩니다. 
- temp_out_canvas_images(temp_file)를 통해서 MiddleFrame의 out_canvas_worker의 img_file을 temp_file로 변경합니다.
- temp_out_canvas_images 메소드는 출력까지만 하고 저장되지 않습니다.

![image](https://github.com/user-attachments/assets/d5691854-ce21-427d-8750-15ea7eb98e20)
텍스트 지우기 후의 이미지

![image](https://github.com/user-attachments/assets/35cc4157-2182-404f-b03b-54df9aa6f3dd)
원상태 복원 후의 이미지