### PR TITLE
feat: #49 remove_tab 원상태 복원 기능 구현

### DIFF
--- a/oot/control/low_remove_control.py
+++ b/oot/control/low_remove_control.py
@@ -60,3 +60,9 @@ def clicked_remove_text():
     from oot.gui.middle_frame import MiddleFrame
     print('[low_remove_control] clicked_search_text() called!!...')
     MiddleFrame.remove_selected_texts()
+
+def clicked_revoke_image(): 
+    from oot.gui.middle_frame import MiddleFrame
+    print('[low_remove_control] clicked_revoke_image() called!!...')
+    temp_file = DataManager.get_work_file().get_file_name()
+    MiddleFrame.temp_out_canvas_image(temp_file)

--- a/oot/control/low_remove_control.py
+++ b/oot/control/low_remove_control.py
@@ -1,7 +1,29 @@
 from abc import *
 from oot.data.data_manager import DataManager
-from oot.gui.common import ScrollableListListener
+from oot.gui.common import ScrollableListListener, CanvasWorkerPostDrawListner
+from oot.gui.subframes.remove_frame import RemoveFrame
 
+class RemovePostDrawHandler(CanvasWorkerPostDrawListner):
+    def do_post_draw(self, canvas, scale_ratio):
+        # draw lines for selected text in check list of remove tab in LowFrame
+            idx = 0
+            list_values = RemoveFrame.remove_tab_text_list.list_values
+            if list_values == None or len(list_values) == 0:
+                return
+            for item in RemoveFrame.remove_tab_text_list.list_values:
+                if item.get() == True:
+                    image_index = DataManager.get_image_index()
+                    work_file = DataManager.folder_data.get_file_by_index(image_index) # FileData
+                    start_pos, end_pos = work_file.get_rectangle_position_by_texts_index(idx)
+                    canvas.create_rectangle(
+                        int(scale_ratio*start_pos[0]),  # start x 
+                        int(scale_ratio*start_pos[1]),  # start y
+                        int(scale_ratio*end_pos[0]),    # end x
+                        int(scale_ratio*end_pos[1]),    # end y
+                        #outline='green'
+                        outline='#00ff00'
+                    )
+                idx = idx + 1
 
 class RemoveTextListHandler(ScrollableListListener):
     def selected_radio_list(self, text):
@@ -31,7 +53,7 @@ def clicked_search_text():
     
     if texts != None:
         from oot.gui.subframes.remove_frame import RemoveFrame
-        scrollable_frame = RemoveFrame.get_frame()
+        scrollable_frame = RemoveFrame.get_remove_tab_text_list()
         scrollable_frame.reset(texts)
 
 def clicked_remove_text(): 

--- a/oot/gui/middle_frame.py
+++ b/oot/gui/middle_frame.py
@@ -42,6 +42,12 @@ class MiddleFrame:
         MiddleFrame.src_canvas_worker = CanvasWorker(src_file, left_canvas)
         MiddleFrame.out_canvas_worker = CanvasWorker(out_file, right_canvas)
 
+    @classmethod
+    def temp_out_canvas_image(cls, temp_file):
+        # temp_file을 임시적으로 out_file로 지정하여 출력하는 메소드(저장은 별개)
+        print ('[MiddleFrame] temp_out_canvas_image() called...')
+        cls.out_canvas_worker.change_image_file(temp_file)
+        cls.redraw_canvas_images()
 
     @classmethod
     def redraw_canvas_images(cls):

--- a/oot/gui/subframes/remove_frame.py
+++ b/oot/gui/subframes/remove_frame.py
@@ -13,10 +13,10 @@ class RemoveFrame:
         self.frame_btn = ttk.Frame(root)
         self.frame_btn.pack(padx=2, pady=2, fill='x')
         
-        from oot.control.low_remove_control import clicked_search_text, clicked_remove_text
+        from oot.control.low_remove_control import clicked_search_text, clicked_remove_text, clicked_revoke_image
         btn_search_text = ttk.Button(self.frame_btn, text='텍스트 찾기', command=clicked_search_text)
         btn_remove_text = ttk.Button(self.frame_btn, text='텍스트 지우기', command=clicked_remove_text)
-        btn_revoke_image = ttk.Button(self.frame_btn, text='원상태 복원')
+        btn_revoke_image = ttk.Button(self.frame_btn, text='원상태 복원', command=clicked_revoke_image)
 
         btn_search_text.pack(side='left')
         btn_remove_text.pack(side='left')

--- a/oot/gui/subframes/remove_frame.py
+++ b/oot/gui/subframes/remove_frame.py
@@ -1,8 +1,5 @@
 from tkinter import ttk
 
-from oot.gui.common import ScrollableList, ScrollableListType
-from oot.control.low_remove_control import RemoveTextListHandler
-
 
 #------------------------------------------------------------------------------
 # Low frame - remove tab : low frame remove tab controls
@@ -25,17 +22,25 @@ class RemoveFrame:
         btn_remove_text.pack(side='left')
         btn_revoke_image.pack(side='left')
 
+        from oot.control.low_remove_control import RemovePostDrawHandler
+        from oot.gui.middle_frame import MiddleFrame
+        MiddleFrame.src_canvas_worker.set_post_draw_listener(RemovePostDrawHandler())
+        MiddleFrame.out_canvas_worker.set_post_draw_listener(RemovePostDrawHandler())
+
+
         remove_tab_down_frm = ttk.Frame(root)
         RemoveFrame.__set_remove_tab_text_list(remove_tab_down_frm)
 
     @classmethod
     def __set_remove_tab_text_list(cls, remove_tab_down_frm):
+        from oot.gui.common import ScrollableList, ScrollableListType
+        from oot.control.low_remove_control import RemoveTextListHandler
         remove_tab_down_frm.pack(padx=2, pady=2, fill='both', expand=True)
         cls.remove_tab_text_list = ScrollableList(remove_tab_down_frm, ScrollableListType.CHECK_BUTTON, RemoveTextListHandler())
         cls.remove_tab_text_list.pack(side="top", fill="x", expand=True)
     
     @classmethod
-    def get_frame(cls):
+    def get_remove_tab_text_list(cls):
         return cls.remove_tab_text_list
 
     @classmethod


### PR DESCRIPTION
b7bb7bf feat: #49 remove_tab 원상태 복원 기능 구현

- remove_tab의 원상태 복원 버튼 클릭 시 clicked_revoke_image()가 실행됩니다.
- temp_out_canvas_image(temp_file)를 통해서 MiddleFrame의 out_canvas_worker의 img_file을 temp_file로 변경합니다.
- temp_out_canvas_image 메소드는 출력까지만 하고 저장되지 않습니다.

![image](https://github.com/user-attachments/assets/d5691854-ce21-427d-8750-15ea7eb98e20)
텍스트 지우기 후의 이미지

![image](https://github.com/user-attachments/assets/35cc4157-2182-404f-b03b-54df9aa6f3dd)
원상태 복원 후의 이미지


03f1467 chore: 구조 변경에 따른 RemovePostDrawHandler 추가

- RemovePostDrawHandler가 추가되었습니다.