### PR TITLE
fix: #103 텍스트 영역 사각형 초기화

### DIFF
--- a/oot/control/low_remove_control.py
+++ b/oot/control/low_remove_control.py
@@ -4,7 +4,7 @@ from oot.gui.common import ScrollableListListener, CanvasWorkerPostDrawListner
 
 
 class RemovePostDrawHandler(CanvasWorkerPostDrawListner):
-    def do_post_draw(self, canvas, scale_ratio):
+    def do_post_draw(self, canvas, scale_ratio, rectangle_ids):
         from oot.gui.subframes.remove_frame import RemoveFrame
         from oot.gui.low_frame import LowFrame
         # draw lines for selected text in check list of remove tab in LowFrame
@@ -19,8 +19,8 @@ class RemovePostDrawHandler(CanvasWorkerPostDrawListner):
                     image_index = DataManager.get_image_index()
                     work_file = DataManager.folder_data.get_file_by_index(image_index) # FileData
                     start_pos, end_pos = work_file.get_rectangle_position_by_texts_index(idx)
-
-                    canvas.create_rectangle(
+                    # 새로운 사각형 그리기
+                    rectangle_id = canvas.create_rectangle(
                         int(scale_ratio*start_pos[0]),  # start x 
                         int(scale_ratio*start_pos[1]),  # start y
                         int(scale_ratio*end_pos[0]),    # end x
@@ -28,6 +28,8 @@ class RemovePostDrawHandler(CanvasWorkerPostDrawListner):
                         #outline='green'
                         outline='#00ff00'
                     )
+                    # 사각형 ID를 CanvasWorker 인스턴스에 저장
+                    rectangle_ids.append(rectangle_id)
                 idx = idx + 1
 
 class RemoveTextListHandler(ScrollableListListener):

--- a/oot/control/low_write_control.py
+++ b/oot/control/low_write_control.py
@@ -7,7 +7,7 @@ from oot.gui.common import ScrollableListListener, CanvasWorkerPostDrawListner
 from oot.gui.subframes.write_frame import WriteFrame
 
 class WritePostDrawHandler(CanvasWorkerPostDrawListner):
-    def do_post_draw(self, canvas, scale_ratio):
+    def do_post_draw(self, canvas, scale_ratio, rectangle_ids):
         from oot.gui.low_frame import LowFrame
         # draw lines for selected text in check list of write tab in LowFrame
         tab_idx = LowFrame.notebook.index(LowFrame.notebook.select())
@@ -18,13 +18,16 @@ class WritePostDrawHandler(CanvasWorkerPostDrawListner):
                 work_file = DataManager.folder_data.get_file_by_index(image_index) # FileData
                 try:
                     start_pos, end_pos = work_file.get_rectangle_position_by_texts_index(idx)
-                    canvas.create_rectangle(
+                    # 새로운 사각형 그리기
+                    rectangle_id = canvas.create_rectangle(
                         int(scale_ratio*start_pos[0]),  # start x 
                         int(scale_ratio*start_pos[1]),  # start y
                         int(scale_ratio*end_pos[0]),    # end x
                         int(scale_ratio*end_pos[1]),    # end y
                         outline='#FF00FF'
                     )
+                    # 사각형 ID를 CanvasWorker 인스턴스에 저장
+                    rectangle_ids.append(rectangle_id)
                 except IndexError:
                     print(f"IndexError: Text index {idx} out of range.")
 

--- a/oot/gui/common.py
+++ b/oot/gui/common.py
@@ -6,7 +6,7 @@ from abc import *
 
 class CanvasWorkerPostDrawListner(metaclass=ABCMeta):
     @abstractmethod
-    def do_post_draw(self, canvas, scale_ratio):
+    def do_post_draw(self, canvas, scale_ratio, rectangle_ids):
         pass
     
 class CanvasWorker:
@@ -21,6 +21,7 @@ class CanvasWorker:
         self.image = Image.open(img_file)
         self.photoimage = None
         self.listeners = []
+        self.rectangle_ids = []  # 사각형이 그려지는 경우, 사각형 ID를 저장할 변수
     
     def draw_image(self):
         self.photoimage = ImageTk.PhotoImage(file=self.img_file)
@@ -42,8 +43,13 @@ class CanvasWorker:
             self.canvas.create_image(0,0, image=self.photoimage, anchor="nw")
             self.scale_ratio = w/w1
 
+        # 기존 사각형 삭제
+        for rectangle_id in self.rectangle_ids:
+            self.canvas.delete(rectangle_id)
+        self.rectangle_ids.clear()
+
         for listener in self.listeners:
-            listener.do_post_draw(self.canvas, self.scale_ratio)
+            listener.do_post_draw(self.canvas, self.scale_ratio, self.rectangle_ids)
 
     def change_image_file(self, img_file):
         self.img_file = img_file


### PR DESCRIPTION
8137790 fix: #103 텍스트 영역 사각형 초기화

- CanvasWorker에 사각형이 그려지는 경우, 사각형 ID를 저장할 변수인 rectangle_ids를 추가했습니다.
- do_post_draw 메소드에 rectangle_ids 파라미터가 추가되어 사각형이 그려지는 경우 rectangle_ids에 저장됩니다.
- draw_image()를 수정하여 기존의 사각형이 있다면 지우고, 새로 그려진 사각형만 화면에 표시됩니다.

![image](https://github.com/user-attachments/assets/b8bee95c-4c28-4e95-ae80-f7bd8cdb374e)
