### PR TITLE
fix: #132 remove_tab 텍스트 지우기 정교화

### DIFF
--- a/test/yunjeong/grayscale.py
+++ b/test/yunjeong/grayscale.py
@@ -1,0 +1,52 @@
+import cv2
+import numpy as np
+
+# 원본 이미지 읽기
+img = cv2.imread('image_path', cv2.IMREAD_COLOR)
+
+# 이진화를 적용할 영역 좌표 (x0, y0)부터 (x1, y1)까지
+x0, y0 = 200, 200
+x1, y1 = 500, 500
+
+# 해당 영역의 이미지 추출
+roi = img[y0:y1, x0:x1]
+
+# # 그레이스케일 변환
+# gray_roi = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+
+# # 이진화 적용 (임계값 127, 최대값 255)
+# _, binary_roi = cv2.threshold(gray_roi, 127, 255, cv2.THRESH_BINARY)
+
+# # 이진화된 부분을 컬러 이미지로 변환
+# binary_roi_color = cv2.cvtColor(binary_roi, cv2.COLOR_GRAY2BGR)
+
+# # 원본 이미지에 이진화된 부분 삽입
+# img[y0:y1, x0:x1] = binary_roi_color
+
+# # 결과 이미지 저장 또는 표시
+# # cv2.imwrite('binary_image.jpg', img)
+# cv2.imshow('gray',gray_roi)
+# cv2.imshow('original' , img)
+
+# cv2.waitKey(0)
+
+
+# # 그레이스케일 변환
+# gray_roi = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+
+# 이진화 적용 (임계값 127, 최대값 255)
+_, binary_roi = cv2.threshold(roi, 127, 255, cv2.THRESH_BINARY)
+
+# # 이진화된 부분을 컬러 이미지로 변환
+# binary_roi_color = cv2.cvtColor(binary_roi, cv2.COLOR_GRAY2BGR)
+
+# 원본 이미지에 이진화된 부분 삽입
+img[y0:y1, x0:x1] = binary_roi
+
+# 결과 이미지 저장 또는 표시
+# cv2.imwrite('binary_image.jpg', img)
+# cv2.imshow('gray',gray_roi)
+cv2.imshow('original' , img)
+cv2.imshow('binary_roi' , binary_roi)
+
+cv2.waitKey(0)

--- a/test/yunjeong/grayscale_gaussian.py
+++ b/test/yunjeong/grayscale_gaussian.py
@@ -1,0 +1,33 @@
+import cv2
+import numpy as np
+
+# 원본 이미지 읽기
+img = cv2.imread('image_path', cv2.IMREAD_COLOR)
+
+# 이진화를 적용할 영역 좌표 (x0, y0)부터 (x1, y1)까지
+x0, y0 = 200, 200
+x1, y1 = 500, 500
+
+# 해당 영역의 이미지 추출
+roi = img[y0:y1, x0:x1]
+
+# 가우시안 블러링
+img_blur = cv2.GaussianBlur(roi, (5,5), 0)
+
+
+# 그레이스케일 변환
+gray_roi = cv2.cvtColor(img_blur, cv2.COLOR_BGR2GRAY)
+
+# 이진화 적용 (임계값 127, 최대값 255)
+_, binary_roi = cv2.threshold(gray_roi, 127, 255, cv2.THRESH_BINARY)
+
+# 이진화된 부분을 컬러 이미지로 변환
+binary_roi_color = cv2.cvtColor(binary_roi, cv2.COLOR_GRAY2BGR)
+
+# 원본 이미지에 이진화된 부분 삽입
+img[y0:y1, x0:x1] = binary_roi_color
+
+cv2.imshow('gray',gray_roi)
+cv2.imshow('original' , img)
+
+cv2.waitKey(0)


### PR DESCRIPTION
34fdb5d fix: #132 remove_tab 텍스트 지우기 정교화

- 해당 텍스트 영역에서 이진화 및 모폴로지를 사용하여 보다 정교한 작업이 이루어지도록 했습니다.
- 이진화 작업에서 Otsu를 선택하는 경우, 글자색에 따라 인식이 달라지는 이슈가 있었습니다. 따라서 adaptive thresholding를 사용하여 정교하게 인식되도록 하였습니다.
- 이미지에 따라 이진화 타입 및 임계값이 달라지므로 모폴로지를 통해 통일된 방식으로 진행되도록 하였습니다.
- 모폴로지의 경우 closing 후 dilation을 거쳐 글자가 최대한 깔끔하게 지워지도록 했습니다.


![image](https://github.com/user-attachments/assets/52bb8651-8fa8-49f0-b498-13fd76b4de4b)
수정 전 텍스트 지우기의 모습

![image](https://github.com/user-attachments/assets/fab4eb59-461c-4abb-8816-f99bad3d2f9d)
수정 후 텍스트 지우기의 모습


![image](https://github.com/user-attachments/assets/7a4aa6da-12cd-4273-bb93-a11441c3a45a)
수정 전 마스크의 모습

![image](https://github.com/user-attachments/assets/02bd711c-a28b-4f13-b74f-8e5e2153dfee)
수정 후 마스크의 모습
